### PR TITLE
feat: add profile config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,6 @@ An array of profile names to use when requesting a token from
 of `chinmina-bridge`, and must be set up in your deployment explicitly.
 For more information, see the [Chinmina documentation][organization-profiles].
 
-Profiles must start with either `repo:` or `org:`, as this will determine whether
-the profile applies at the organization level (globally) or at the repo level.
-This affects caching behaviour in Chinmina.
-
 ## Developing
 
 Run tests and plugin linting locally using `docker compose`:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ steps:
       - chinmina/chinmina-git-credentials#v1.1.0:
           chinmina-url: "https://chinmina-bridge-url"
           audience: "chinmina:your-github-organization"
+          profile: "buildkite-plugins"
 ```
 
 ## Configuration
@@ -54,6 +55,13 @@ to the purpose of the token, and also scoped to the GitHub organization that
 tokens will be vended for. `chinmina-bridge`'s GitHub app is configured for a
 particular GitHub organization/user, so if you have multiple organizations,
 multiple agents will need to be running.
+
+### `profile` (string)
+
+The name of the profile to use when requesting a token from
+[`chinmina-bridge`][chinmina-bridge]. Organization profiles are stored outside
+of `chinmina-bridge` itself, and must be set up in your deployment explicitly.
+For more information, see the [Chinmina documentation][organization-profiles].
 
 ## Developing
 
@@ -79,3 +87,4 @@ Contributions are welcome! Raise a PR, and include tests with your changes.
 
 [chinmina-bridge]: https://chinmina.github.io/introduction/
 [chinmina-integration]: https://chinmina.github.io/guides/buildkite-integration/
+[organization-profiles]: https://chinmina.github.io/reference/organization-profile/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ steps:
       - chinmina/chinmina-git-credentials#v1.1.0:
           chinmina-url: "https://chinmina-bridge-url"
           audience: "chinmina:your-github-organization"
-          profile: "buildkite-plugins"
+          profiles: "repo:default org:buildkite-plugins"
 ```
 
 ## Configuration
@@ -56,12 +56,17 @@ tokens will be vended for. `chinmina-bridge`'s GitHub app is configured for a
 particular GitHub organization/user, so if you have multiple organizations,
 multiple agents will need to be running.
 
-### `profile` (string)
+### `profiles` (string)
 
-The name of the profile to use when requesting a token from
+**Default:** `repo:default`
+
+The name of the profiles (in space-separated format) to use when requesting a token from
 [`chinmina-bridge`][chinmina-bridge]. Organization profiles are stored outside
 of `chinmina-bridge` itself, and must be set up in your deployment explicitly.
 For more information, see the [Chinmina documentation][organization-profiles].
+
+Profiles must start with either `repo:` or `org:`, as this will determine whether the profile applies at the organization level (globally)
+or at the repo level. This affects caching behaviour in Chinmina.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ steps:
       - chinmina/chinmina-git-credentials#v1.1.0:
           chinmina-url: "https://chinmina-bridge-url"
           audience: "chinmina:your-github-organization"
-          profiles: "repo:default org:buildkite-plugins"
+          profiles: 
+            - repo:default
+            - org:buildkite-plugins
 ```
 
 ## Configuration
@@ -56,17 +58,18 @@ tokens will be vended for. `chinmina-bridge`'s GitHub app is configured for a
 particular GitHub organization/user, so if you have multiple organizations,
 multiple agents will need to be running.
 
-### `profiles` (string)
+### `profiles` (array)
 
-**Default:** `repo:default`
+**Default:** [`repo:default`]
 
-The name of the profiles (in space-separated format) to use when requesting a token from
+An array of profile names to use when requesting a token from
 [`chinmina-bridge`][chinmina-bridge]. Organization profiles are stored outside
-of `chinmina-bridge` itself, and must be set up in your deployment explicitly.
+of `chinmina-bridge`, and must be set up in your deployment explicitly.
 For more information, see the [Chinmina documentation][organization-profiles].
 
-Profiles must start with either `repo:` or `org:`, as this will determine whether the profile applies at the organization level (globally)
-or at the repo level. This affects caching behaviour in Chinmina.
+Profiles must start with either `repo:` or `org:`, as this will determine whether
+the profile applies at the organization level (globally) or at the repo level.
+This affects caching behaviour in Chinmina.
 
 ## Developing
 

--- a/credential-helper/buildkite-connector-credential-helper
+++ b/credential-helper/buildkite-connector-credential-helper
@@ -1,9 +1,17 @@
 #!/bin/bash
 set -eou pipefail
+# Because git passes in additional information, we need to assign based on the number
+# of arguments passed in.
 
 url="${1:?url parameter required}"
 audience="${2:?audience parameter required}"
-action="${3:?action parameter required}"
+if [[ "$#" -eq 3 ]]; then
+  action="${3:?action parameter required}" 
+  profile=""
+elif [[ "$#" -eq 4 ]]; then
+  profile="${3}"
+  action="${4:?action parameter required}"
+fi
 
 # ignore unsupported actions without error
 if [[ "${action}" != "get" ]]; then
@@ -23,10 +31,18 @@ time {
 # OIDC JWT from the agent. The output of this request is in the expected format,
 # so is sent to stdout to be read by git.
 TIMEFORMAT='[token vendor = %2Rs]'
-time curl --silent --show-error --fail \
+if [[ -z "${profile}" ]]; then
+  time curl --silent --show-error --fail \
     --request POST "${url}/git-credentials" \
     --data "${args}" \
     --header "Authorization: Bearer ${oidc_auth_token}" \
     --header "Content-Type: text/plain" \
     --header "Accept: text/plain"
-
+else
+time curl --silent --show-error --fail \
+    --request POST "${url}/organization/git-credentials/${profile}" \
+    --data "${args}" \
+    --header "Authorization: Bearer ${oidc_auth_token}" \
+    --header "Content-Type: text/plain" \
+    --header "Accept: text/plain"
+fi

--- a/credential-helper/buildkite-connector-credential-helper
+++ b/credential-helper/buildkite-connector-credential-helper
@@ -30,7 +30,9 @@ fi
 # OIDC JWT from the agent. The output of this request is in the expected format,
 # so is sent to stdout to be read by git.
 TIMEFORMAT='[token vendor = %2Rs]'
-if [[ ${profile} == "default" ]]; then
+# support both the old and new default profile name
+# TODO: tidy up this conditional once chinmina profile support is rolled out
+if [[ ${profile} == "default" || ${profile} == "repo:default" ]]; then
   path="git-credentials"
 else
   path="organization/git-credentials/${profile}"

--- a/credential-helper/buildkite-connector-credential-helper
+++ b/credential-helper/buildkite-connector-credential-helper
@@ -1,17 +1,10 @@
 #!/bin/bash
 set -eou pipefail
-# Because git passes in additional information, we need to assign based on the number
-# of arguments passed in.
 
 url="${1:?url parameter required}"
 audience="${2:?audience parameter required}"
-if [[ "$#" -eq 3 ]]; then
-  action="${3:?action parameter required}" 
-  profile=""
-elif [[ "$#" -eq 4 ]]; then
-  profile="${3}"
-  action="${4:?action parameter required}"
-fi
+profile="${3:?profile parameter required}"
+action="${4:?action parameter required}"
 
 # ignore unsupported actions without error
 if [[ "${action}" != "get" ]]; then
@@ -31,18 +24,16 @@ time {
 # OIDC JWT from the agent. The output of this request is in the expected format,
 # so is sent to stdout to be read by git.
 TIMEFORMAT='[token vendor = %2Rs]'
-if [[ -z "${profile}" ]]; then
-  time curl --silent --show-error --fail \
-    --request POST "${url}/git-credentials" \
-    --data "${args}" \
-    --header "Authorization: Bearer ${oidc_auth_token}" \
-    --header "Content-Type: text/plain" \
-    --header "Accept: text/plain"
+if [[ ${profile} == "default" ]]; then
+  path="git-credentials"
 else
-time curl --silent --show-error --fail \
-    --request POST "${url}/organization/git-credentials/${profile}" \
-    --data "${args}" \
-    --header "Authorization: Bearer ${oidc_auth_token}" \
-    --header "Content-Type: text/plain" \
-    --header "Accept: text/plain"
+  path="organization/git-credentials/${profile}"
 fi
+
+time curl --silent --show-error --fail \
+  --request POST "${url}/${path}" \
+  --data "${args}" \
+  --header "Authorization: Bearer ${oidc_auth_token}" \
+  --header "Content-Type: text/plain" \
+  --header "Accept: text/plain"
+

--- a/credential-helper/buildkite-connector-credential-helper
+++ b/credential-helper/buildkite-connector-credential-helper
@@ -13,12 +13,18 @@ fi
 # read credential helper input from stdin
 args="$(< /dev/stdin)"
 
-# timings are output to stderr, which Git ignores.
-
-TIMEFORMAT='[oidc = %2Rs]'
-time {
-  oidc_auth_token="$(buildkite-agent oidc request-token --claim pipeline_id --audience "${audience}")"
-}
+# caches the OIDC token for 5 minutes, so that successive calls to the credential helper use the existing token
+cache_file="/tmp/oidc_auth_token_${BUILDKITE_JOB_ID}.cache"
+if [[ -f "${cache_file}" && -s "${cache_file}" && $(find "${cache_file}" -mmin -5) ]]; then
+  oidc_auth_token="$(< "${cache_file}")"
+else 
+  # timings are output to stderr, which Git ignores.
+  TIMEFORMAT='[oidc = %2Rs]'
+  time {
+    oidc_auth_token="$(buildkite-agent oidc request-token --claim pipeline_id --audience "${audience}")"
+  }
+  echo "${oidc_auth_token}" > "${cache_file}"
+fi
 
 # Request a token for the given repository from the remote server, using the
 # OIDC JWT from the agent. The output of this request is in the expected format,

--- a/hooks/environment
+++ b/hooks/environment
@@ -92,10 +92,12 @@ git_config_add "credential.https://github.com.usehttppath" "true"
 
 # iterate over all provided profiles and configure a credential helper for each one
 for profile in "${profiles[@]}"; do
-  if [[ "${profile}" != org:* && "${profile}" != repo:* ]]; then
-    echo "~~~ :error: Invalid profile: ${profile}. Must start with 'org:' or 'repo:'"
-    exit 1
-  fi
+  # support both the old and new default profile name
+  # TODO: uncomment the below code once chinmina profile support is rolled out
+  # if [[ "${profile}" != org:* && "${profile}" != repo:* ]]; then
+  #   echo "~~~ :error: Invalid profile: ${profile}. Must start with 'org:' or 'repo:'"
+  #   exit 1
+  # fi
   git_config_add "credential.https://github.com.helper" "${plugin_root}/credential-helper/buildkite-connector-credential-helper ${chinmina_url} ${audience} ${profile}"
 done
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -4,6 +4,7 @@ set -euo pipefail
 original_prefix="BUILDKITE_PLUGIN_GITHUB_APP_AUTH_"
 prefix="BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_"
 
+
 get_parameter() {
   local key="$1"
   local name="${prefix}${key}"
@@ -19,6 +20,9 @@ get_parameter() {
 chinmina_url="$(get_parameter "CHINMINA_URL")"
 vendor_url_compat="$(get_parameter "VENDOR_URL")"
 audience="$(get_parameter "AUDIENCE")"
+profile="$(get_parameter "PROFILE")"
+
+echo "Profile: $profile"
 
 # allow the old name of the parameter to be used
 chinmina_url="${chinmina_url:-$vendor_url_compat}"
@@ -55,5 +59,8 @@ git_config_add() {
     export "GIT_CONFIG_VALUE_${index}=${value}"
 }
 
+
+
 git_config_add "credential.https://github.com.usehttppath" "true"
-git_config_add "credential.https://github.com.helper" "${plugin_root}/credential-helper/buildkite-connector-credential-helper ${chinmina_url} ${audience}"
+git_config_add "credential.https://github.com.helper" "${plugin_root}/credential-helper/buildkite-connector-credential-helper ${chinmina_url} ${audience} ${profile}"
+

--- a/hooks/environment
+++ b/hooks/environment
@@ -4,6 +4,28 @@ set -euo pipefail
 original_prefix="BUILDKITE_PLUGIN_GITHUB_APP_AUTH_"
 prefix="BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_"
 
+# Reads either a value or a list from plugin config into a global result array
+# Returns success if values were read
+# Inspired by: https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/blob/4ac4d6d/lib/shared.bash#L69-L87
+plugin_read_list_into_result() {
+  local prefix="$1"
+  local parameter="${prefix}_0"
+  result=()
+
+  if [[ -n "${!parameter:-}" ]]; then
+    local i=0
+    local parameter="${prefix}_${i}"
+    while [[ -n "${!parameter:-}" ]]; do
+      result+=("${!parameter}")
+      i=$((i+1))
+      parameter="${prefix}_${i}"
+    done
+  elif [[ -n "${!prefix:-}" ]]; then
+    result+=("${!prefix}")
+  fi
+
+  [[ ${#result[@]} -gt 0 ]] || return 1
+}
 
 get_parameter() {
   local key="$1"
@@ -20,9 +42,6 @@ get_parameter() {
 chinmina_url="$(get_parameter "CHINMINA_URL")"
 vendor_url_compat="$(get_parameter "VENDOR_URL")"
 audience="$(get_parameter "AUDIENCE")"
-profiles="$(get_parameter "PROFILES")"
-
-echo "Profile: $profiles"
 
 # allow the old name of the parameter to be used
 chinmina_url="${chinmina_url:-$vendor_url_compat}"
@@ -36,8 +55,14 @@ if [ -z "$audience" ]; then
   audience="chinmina:default"
 fi
 
-if [ -z "$profiles" ]; then
-  profiles="repo:default"
+profiles=()
+# read profiles from the plugin config, returns an array
+if plugin_read_list_into_result "${prefix}PROFILES"; then
+  profiles=("${result[@]}")
+fi
+
+if [[ ${#profiles[@]} -eq 0 ]]; then
+  profiles=("repo:default")
 fi
 
 echo "~~~ :git: :github: Configuring Git to authenticate via Chinmina"
@@ -63,13 +88,12 @@ git_config_add() {
     export "GIT_CONFIG_VALUE_${index}=${value}"
 }
 
-
-
 git_config_add "credential.https://github.com.usehttppath" "true"
 
-for profile in ${profiles}; do
-  if [[ "$profile" != org:* && "$profile" != repo:* ]]; then
-    echo "~~~ :error: Invalid profile: $profile. Must start with 'org:' or 'repo:'"
+# iterate over all provided profiles and configure a credential helper for each one
+for profile in "${profiles[@]}"; do
+  if [[ "${profile}" != org:* && "${profile}" != repo:* ]]; then
+    echo "~~~ :error: Invalid profile: ${profile}. Must start with 'org:' or 'repo:'"
     exit 1
   fi
   git_config_add "credential.https://github.com.helper" "${plugin_root}/credential-helper/buildkite-connector-credential-helper ${chinmina_url} ${audience} ${profile}"

--- a/hooks/environment
+++ b/hooks/environment
@@ -20,9 +20,9 @@ get_parameter() {
 chinmina_url="$(get_parameter "CHINMINA_URL")"
 vendor_url_compat="$(get_parameter "VENDOR_URL")"
 audience="$(get_parameter "AUDIENCE")"
-profile="$(get_parameter "PROFILE")"
+profiles="$(get_parameter "PROFILES")"
 
-echo "Profile: $profile"
+echo "Profile: $profiles"
 
 # allow the old name of the parameter to be used
 chinmina_url="${chinmina_url:-$vendor_url_compat}"
@@ -34,6 +34,10 @@ fi
 
 if [ -z "$audience" ]; then
   audience="chinmina:default"
+fi
+
+if [ -z "$profiles" ]; then
+  profiles="default"
 fi
 
 echo "~~~ :git: :github: Configuring Git to authenticate via Chinmina"
@@ -62,5 +66,8 @@ git_config_add() {
 
 
 git_config_add "credential.https://github.com.usehttppath" "true"
-git_config_add "credential.https://github.com.helper" "${plugin_root}/credential-helper/buildkite-connector-credential-helper ${chinmina_url} ${audience} ${profile}"
+
+for profile in ${profiles}; do
+  git_config_add "credential.https://github.com.helper" "${plugin_root}/credential-helper/buildkite-connector-credential-helper ${chinmina_url} ${audience} ${profile}"
+done
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -37,7 +37,7 @@ if [ -z "$audience" ]; then
 fi
 
 if [ -z "$profiles" ]; then
-  profiles="default"
+  profiles="repo:default"
 fi
 
 echo "~~~ :git: :github: Configuring Git to authenticate via Chinmina"
@@ -68,6 +68,10 @@ git_config_add() {
 git_config_add "credential.https://github.com.usehttppath" "true"
 
 for profile in ${profiles}; do
+  if [[ "$profile" != org:* && "$profile" != repo:* ]]; then
+    echo "~~~ :error: Invalid profile: $profile. Must start with 'org:' or 'repo:'"
+    exit 1
+  fi
   git_config_add "credential.https://github.com.helper" "${plugin_root}/credential-helper/buildkite-connector-credential-helper ${chinmina_url} ${audience} ${profile}"
 done
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -18,4 +18,10 @@ configuration:
         (Default `chinmina:default`.) The audience to use for the Buildkite OIDC
         JWT that is sent to the vendor agent. Must match the setting in the
         vendor agent.
+    profile:
+      type: string
+      description: |
+        The name of the profile to use for the Git credential helper. If unset,
+        the default profile and endpoint will be used to obtain tokens for the
+        current pipeline.
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -18,10 +18,10 @@ configuration:
         (Default `chinmina:default`.) The audience to use for the Buildkite OIDC
         JWT that is sent to the vendor agent. Must match the setting in the
         vendor agent.
-    profile:
-      type: string
+    profiles:
+      type: array
       description: |
-        The name of the profile to use for the Git credential helper. If unset,
+        The name of the profiles to use for the Git credential helper, space-separated. If unset,
         the default profile and endpoint will be used to obtain tokens for the
         current pipeline.
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -19,9 +19,9 @@ configuration:
         JWT that is sent to the vendor agent. Must match the setting in the
         vendor agent.
     profiles:
-      type: string
+      type: array
       description: |
-        The name of the profiles to use for the Git credential helper, space-separated. If unset,
+        An array of profiles to use for the Git credential helper. If unset,
         the default profile and endpoint will be used to obtain tokens for the
         current pipeline.
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -19,7 +19,7 @@ configuration:
         JWT that is sent to the vendor agent. Must match the setting in the
         vendor agent.
     profiles:
-      type: array
+      type: string
       description: |
         The name of the profiles to use for the Git credential helper, space-separated. If unset,
         the default profile and endpoint will be used to obtain tokens for the

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -28,7 +28,8 @@ setup() {
 teardown() {
   unset BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_CHINMINA_URL
   unset BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_AUDIENCE
-  unset BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_PROFILES
+  unset BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_PROFILES_0
+  unset BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_PROFILES_1
 
   clear_git_config
 }
@@ -46,7 +47,7 @@ run_environment() {
 
 @test "Fails with invalid profiles" {
   export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_CHINMINA_URL=http://test-location
-  export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_PROFILES="invalid-test-profile"
+  export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_PROFILES_0="invalid-test-profile"
 
   run "$PWD/hooks/environment"
 
@@ -82,10 +83,25 @@ run_environment() {
   assert_line --regexp "GIT_CONFIG_VALUE_1=/.*/credential-helper/buildkite-connector-credential-helper http://test-location test-audience"
 }
 
+@test "Adds config for default profile" {
+  export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_CHINMINA_URL=http://test-location
+  export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_AUDIENCE=test-audience
+
+  run_environment "${PWD}/hooks/environment"
+
+  assert_success
+  assert_line "GIT_CONFIG_COUNT=2"
+  assert_line "GIT_CONFIG_KEY_0=credential.https://github.com.usehttppath"
+  assert_line "GIT_CONFIG_VALUE_0=true"
+  assert_line "GIT_CONFIG_KEY_1=credential.https://github.com.helper"
+  assert_line --regexp "GIT_CONFIG_VALUE_1=/.*/credential-helper/buildkite-connector-credential-helper http://test-location test-audience repo:default"
+}
+
 @test "Adds config for non-default profiles" {
   export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_CHINMINA_URL=http://test-location
   export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_AUDIENCE=test-audience
-  export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_PROFILES="org:test-profile repo:another-test-profile"
+  export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_PROFILES_0="org:test-profile"
+  export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_PROFILES_1="repo:another-test-profile"
 
   run_environment "${PWD}/hooks/environment"
 

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -70,6 +70,21 @@ run_environment() {
   assert_line --regexp "GIT_CONFIG_VALUE_1=/.*/credential-helper/buildkite-connector-credential-helper http://test-location test-audience"
 }
 
+@test "Adds config for non-default profile" {
+  export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_CHINMINA_URL=http://test-location
+  export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_AUDIENCE=test-audience
+  export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_PROFILE=test-profile
+
+  run_environment "${PWD}/hooks/environment"
+
+  assert_success
+  assert_line "GIT_CONFIG_COUNT=2"
+  assert_line "GIT_CONFIG_KEY_0=credential.https://github.com.usehttppath"
+  assert_line "GIT_CONFIG_VALUE_0=true"
+  assert_line "GIT_CONFIG_KEY_1=credential.https://github.com.helper"
+  assert_line --regexp "GIT_CONFIG_VALUE_1=/.*/credential-helper/buildkite-connector-credential-helper http://test-location test-audience test-profile"
+}
+
 @test "Backwards compatible with old name" {
   export BUILDKITE_PLUGIN_GITHUB_APP_AUTH_VENDOR_URL=http://test-location
   export BUILDKITE_PLUGIN_GITHUB_APP_AUTH_AUDIENCE=test-audience

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -45,17 +45,6 @@ run_environment() {
   assert_line --partial "Missing required parameter chinmina-url"
 }
 
-@test "Fails with invalid profiles" {
-  export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_CHINMINA_URL=http://test-location
-  export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_PROFILES_0="invalid-test-profile"
-
-  run "$PWD/hooks/environment"
-
-  assert_failure
-  assert_line --partial "Invalid profile"
-}
-
-
 @test "Adds config for default audience" {
   export BUILDKITE_PLUGIN_CHINMINA_GIT_CREDENTIALS_CHINMINA_URL=http://test-location
 


### PR DESCRIPTION
This PR adds the ability to use profiles inside of the Chinmina plugin.

The credentials helper will select the correct endpoint to use, based on whether a `profile` value is supplied or not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a configuration option to specify multiple profiles for token requests.
  - Enhanced the Git credential helper to support multiple profiles and adjust the endpoint based on the selected profile.
  - Added a new configuration property for defining multiple profiles in the plugin settings.

- **Bug Fixes**
  - Implemented error handling for invalid profiles in the configuration.

- **Tests**
  - Added test cases to verify behavior with both default and non-default profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->