### PR TITLE
feat: include optional OIDC claims for profile matching

### DIFF
--- a/credential-helper/buildkite-connector-credential-helper
+++ b/credential-helper/buildkite-connector-credential-helper
@@ -7,6 +7,8 @@ profile="${3:?profile parameter required}"
 action="${4:?action parameter required}"
 : "${TMPDIR:?TMPDIR environment variable required}"
 
+additional_oidc_claims="pipeline_id,cluster_id,cluster_name,queue_id,queue_key"
+
 # ignore unsupported actions without error
 if [[ "${action}" != "get" ]]; then
     exit 0
@@ -23,7 +25,7 @@ if ! oidc_auth_token="$(cache_read "${BUILDKITE_JOB_ID}")"; then
   # timings are output to stderr, which Git ignores.
   TIMEFORMAT='[oidc = %2Rs]'
   time {
-    oidc_auth_token="$(buildkite-agent oidc request-token --claim pipeline_id --audience "${audience}")"
+    oidc_auth_token="$(buildkite-agent oidc request-token --claim "${additional_oidc_claims}" --audience "${audience}")"
   }
   cache_write "${BUILDKITE_JOB_ID}" "${oidc_auth_token}"
 fi


### PR DESCRIPTION
## Purpose

Enable Chinmina's conditional profile support by including optional claims in the OIDC token. The plugin now requests additional claims (pipeline_id, cluster_id, cluster_name, queue_id, queue_key) from Buildkite's OIDC token endpoint, which allows profile configurations to use match expressions based on pipeline and cluster context. Without these claims, conditional profile matching expressions cannot evaluate and will fail to grant appropriate access.

## Context

- Chinmina Bridge PR introducing conditional profile support: https://github.com/chinmina/chinmina-bridge/pull/131
- Profile access control documentation: https://chinmina.github.io/guides/profile-access-control/#available-claims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OIDC tokens now include expanded claims (pipeline_id, cluster_id, cluster_name, queue_id, queue_key) to provide richer credential context.

* **Chores**
  * Token caching behavior and storage location remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->